### PR TITLE
Update json gem version to fix deploy issue.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     jquery-rails (3.0.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.0)
+    json (1.8.2)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)


### PR DESCRIPTION
When deploying the survey app to the latest stable-v4 stack on EY, it fails for being unable to build the native extensions for json 1.8.0. Then, I noticed that json 1.8.2 is already installed in the system gems. This change simply updates json gem version in Gemfile.lock to 1.8.2.
